### PR TITLE
Convert some h2's into h3's in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ repo.
 
 [example-graphql-servier]: ./example_graphql_server/index.js
 
-## A more complex GraphQL schema
+### A more complex GraphQL schema
 
 The GraphQL schema:
 
@@ -165,7 +165,7 @@ Becomes:
 }
 ```
 
-## Limitations of nesting
+### Limitations of nesting
 
 GraphQL's introspection system doesn't make it possible to get arbitrarily-deep
 arrays or non-null values. As a result, at a certain point `graphql-to-jddf`
@@ -241,7 +241,7 @@ And so becomes (note the lack of `{"type": "string"}`):
 }
 ```
 
-## Limitations of unions and interfaces
+### Limitations of unions and interfaces
 
 `graphql-to-jddf` produces less-than-ideal output for GraphQL interfaces and
 unions:


### PR DESCRIPTION
There are some h2's in the README that ought to be h3's. This PR addresses them.